### PR TITLE
Added aria accessibility attributes to form controls

### DIFF
--- a/src/AccessibilityHelper.php
+++ b/src/AccessibilityHelper.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tomaj\Form\Renderer;
+
+use Nette\Forms\Control;
+use Nette\Forms\Form;
+use Nette\Utils\Html;
+
+class AccessibilityHelper
+{
+    public static function addAccessibilityMetaDataToControl(Form $form, Control $control, array $wrappers)
+    {
+        // handle aria meta data for errors
+        if (!empty($control->getErrors())) {
+            $htmlIdPrefix = $control->getHtmlId() . '-aria-describe_';
+
+            $ariaDescribedBy = [];
+            foreach ($control->getErrors() as $key => $error) {
+                $ariaDescribedBy[] = $htmlIdPrefix . $key;
+            }
+            $control->getControlPrototype()->addAttributes([
+                'aria-invalid' => 'true',
+                'aria-describedby' => implode(' ', $ariaDescribedBy),
+            ]);
+
+            $errors = $control->getErrors();
+            $control->cleanErrors();
+            foreach ($errors as $key => $text) {
+                $el = Html::el(
+                    'span',
+                    [
+                        'id' => $htmlIdPrefix . $key
+                    ]
+                );
+                $el->setText($text);
+                $control->addError($el);
+            }
+        }
+
+        // handler aria meta data for description
+        if (!empty($control->getOption('description'))) {
+            $htmlId = $control->getHtmlId() . '-aria-describe_description';
+
+            $ariaDescribedBy = $control->getControlPrototype()->getAttribute('aria-describedby');
+            $control->getControlPrototype()->setAttribute(
+                'aria-describedby',
+                $ariaDescribedBy . ($ariaDescribedBy ? ' ' : '') . $htmlId
+            );
+
+            $description = $control->getOption('description');
+            if (is_string($description)) {
+                $el = Html::el(
+                    $wrappers['control']['description'],
+                    [
+                        'id' => $htmlId
+                    ]
+                );
+                $el->setText($form->getTranslator()->translate($description));
+                $control->setOption('description', $el);
+            } else {
+                $description->setAttribute('id', $htmlId);
+            }
+        }
+    }
+}

--- a/src/BootstrapInlineRenderer.php
+++ b/src/BootstrapInlineRenderer.php
@@ -93,6 +93,8 @@ class BootstrapInlineRenderer extends DefaultFormRenderer
                 $control instanceof RadioList) {
                 $control->getSeparatorPrototype()->setName('div')->addClass($control->getControlPrototype()->type);
             }
+
+            AccessibilityHelper::addAccessibilityMetaDataToControl($form, $control, $this->wrappers);
         }
 
         return parent::render($form, $mode);

--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -93,6 +93,8 @@ class BootstrapRenderer extends DefaultFormRenderer
                 $control instanceof RadioList) {
                 $control->getSeparatorPrototype()->setName('div')->addClass($control->getControlPrototype()->type);
             }
+
+            AccessibilityHelper::addAccessibilityMetaDataToControl($form, $control, $this->wrappers);
         }
 
         return parent::render($form, $mode);

--- a/src/BootstrapVerticalRenderer.php
+++ b/src/BootstrapVerticalRenderer.php
@@ -11,6 +11,7 @@ use Nette\Forms\Controls\SelectBox;
 use Nette\Forms\Controls\TextBase;
 use Nette\Forms\Form;
 use Nette\Forms\Rendering\DefaultFormRenderer;
+use Nette\Utils\Html;
 
 class BootstrapVerticalRenderer extends DefaultFormRenderer
 {
@@ -85,13 +86,16 @@ class BootstrapVerticalRenderer extends DefaultFormRenderer
                 }
             } elseif ($control instanceof TextBase ||
                 $control instanceof SelectBox ||
-                $control instanceof MultiSelectBox) {
+                $control instanceof MultiSelectBox
+            ) {
                 $control->getControlPrototype()->addClass('form-control');
             } elseif ($control instanceof Checkbox ||
                 $control instanceof CheckboxList ||
                 $control instanceof RadioList) {
                 $control->getSeparatorPrototype()->setName('div')->addClass($control->getControlPrototype()->type);
             }
+
+            AccessibilityHelper::addAccessibilityMetaDataToControl($form, $control, $this->wrappers);
         }
 
         return parent::render($form, $mode);


### PR DESCRIPTION
Added aria accessibility attributes to form controls:

- added `aria-invalid="true"` to not valid form controls
- added `aria-describedby` to error messages and control descriptions

aria docs:
- **aria-invalid**: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid
- **aria-describedby**: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby

I'll explain implementation in commit comments.